### PR TITLE
Prevent NPE in getFik when response contains error

### DIFF
--- a/src/main/java/cz/tomasdvorak/eet/client/dto/SubmitResult.java
+++ b/src/main/java/cz/tomasdvorak/eet/client/dto/SubmitResult.java
@@ -51,6 +51,6 @@ public class SubmitResult extends OdpovedType {
      * @return FIK code from the response. May be {@code null}, if the response contains errors
      */
     public String getFik() {
-        return getPotvrzeni().getFik();
+        return getPotvrzeni() == null ? null : getPotvrzeni().getFik();
     }
 }


### PR DESCRIPTION
Original implementation was causing NullPointerException when calling getFik(), as 'Potvrzeni' object was null.