### PR TITLE
Created interceptors to properly validate signature based on message body

### DIFF
--- a/src/main/java/cz/tomasdvorak/eet/client/security/SecureEETCommunication.java
+++ b/src/main/java/cz/tomasdvorak/eet/client/security/SecureEETCommunication.java
@@ -1,31 +1,27 @@
 package cz.tomasdvorak.eet.client.security;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.ws.BindingProvider;
+
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.frontend.ClientProxy;
+import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
+import org.apache.cxf.transport.http.HTTPConduit;
+import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
+import org.apache.cxf.ws.security.wss4j.WSS4JInInterceptor;
+import org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor;
+import org.apache.wss4j.dom.handler.WSHandlerConstants;
+
 import cz.etrzby.xml.EET;
 import cz.etrzby.xml.EETService;
 import cz.tomasdvorak.eet.client.config.CommunicationMode;
 import cz.tomasdvorak.eet.client.config.EndpointType;
 import cz.tomasdvorak.eet.client.dto.WebserviceConfiguration;
+import cz.tomasdvorak.eet.client.logging.WebserviceLogging;
 import cz.tomasdvorak.eet.client.timing.TimingReceiveInterceptor;
 import cz.tomasdvorak.eet.client.timing.TimingSendInterceptor;
-import cz.tomasdvorak.eet.client.logging.WebserviceLogging;
-import org.apache.cxf.binding.soap.SoapMessage;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.frontend.ClientProxy;
-import org.apache.cxf.interceptor.Fault;
-import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
-import org.apache.cxf.message.Message;
-import org.apache.cxf.transport.http.HTTPConduit;
-import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
-import org.apache.cxf.ws.security.wss4j.WSS4JInInterceptor;
-import org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor;
-import org.apache.logging.log4j.Logger;
-import org.apache.wss4j.dom.handler.WSHandlerConstants;
-
-import javax.xml.ws.BindingProvider;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class SecureEETCommunication {
 
@@ -48,9 +44,7 @@ public class SecureEETCommunication {
      * Service instance is thread safe and cachable, so create just one instance during initialization of the class
      */
     private static final EETService WEBSERVICE = new EETService();
-
-    private static final Logger logger = org.apache.logging.log4j.LogManager.getLogger(SecureEETCommunication.class);
-
+    
     /**
      * Signing of data and requests
      */
@@ -84,7 +78,7 @@ public class SecureEETCommunication {
         configureSchemaValidation(port);
         configureTimeout(clientProxy);
         configureLogging(clientProxy);
-        configureSigning(clientProxy, mode);
+        configureSigning(clientProxy);
         return port;
     }
 
@@ -103,17 +97,18 @@ public class SecureEETCommunication {
     /**
      * Sign our request with the client key par.
      */
-    private void configureSigning(final Client clientProxy, final CommunicationMode mode) {
+    private void configureSigning(final Client clientProxy) {
         final WSS4JOutInterceptor wssOut = createSigningInterceptor();
         clientProxy.getOutInterceptors().add(wssOut);
-        final WSS4JInInterceptor wssIn = createValidatingInterceptor(mode);
+        final WSS4JInInterceptor wssIn = createValidatingInterceptor();
         clientProxy.getInInterceptors().add(wssIn);
+        clientProxy.getInInterceptors().add(new SignatureFaultInterceptor());
     }
 
     /**
      * Checks, if the response is signed by a key produced by CA, which do we accept (provided to this client)
      */
-    private WSS4JInInterceptor createValidatingInterceptor(final CommunicationMode mode) {
+    private WSS4JInInterceptor createValidatingInterceptor() {
         final Map<String,Object> inProps = new HashMap<String,Object>();
         inProps.put(WSHandlerConstants.ACTION, WSHandlerConstants.SIGNATURE); // only sign, do not encrypt
 
@@ -123,42 +118,7 @@ public class SecureEETCommunication {
         inProps.put(WSHandlerConstants.SIG_SUBJECT_CERT_CONSTRAINTS, SUBJECT_CERT_CONSTRAINTS); // regex validation of the cert.
         inProps.put(WSHandlerConstants.ENABLE_REVOCATION, "true"); // activate CRL checks
 
-        return new WSS4JInInterceptor(inProps) {
-
-            /**
-             * This is a giant and unsecure HACK! The response is digitally signed only, when the communication mode is set to REAL (overeni=false)
-             * and the response is valid (which cannot be checked in advance).
-             *
-             * So our only change is to check the signature only, when the communication is set to real and there is no
-             * error in response.
-             */
-            @Override
-            public void handleMessage(final SoapMessage msg) throws Fault {
-                if (mode.isCheckOnly()) {
-                    logger.warn("Running in " + mode + " mode, no response signature verification available!");
-                } else if (isErrorResponse(msg)) {
-                    logger.warn("Validation error, no response signature verification available!");
-                } else {
-                    super.handleMessage(msg);
-                }
-            }
-        };
-    }
-
-    /**
-     * Check, whether the response contains error headers.
-     * TODO: is there a better solution?
-     */
-    private boolean isErrorResponse(final SoapMessage msg) {
-        final Map<String, List<String>> headers = (Map<String, List<String>>) msg.get(Message.PROTOCOL_HEADERS);
-        final List<String> strings = headers.get("X-Backside-Transport");
-        for(final String header : strings) {
-            final List<String> split = Arrays.asList(header.split(" "));
-            if(split.contains("FAIL")) {
-                return true;
-            }
-        }
-        return false;
+       return new WSS4JEetInInterceptor(inProps);
     }
 
     private WSS4JOutInterceptor createSigningInterceptor() {
@@ -173,7 +133,7 @@ public class SecureEETCommunication {
         signingProperties.put(WSHandlerConstants.SIG_KEY_ID, "DirectReference"); // embed the public cert into requests
         signingProperties.put(WSHandlerConstants.SIG_ALGO, "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
         signingProperties.put(WSHandlerConstants.SIG_DIGEST_ALGO, "http://www.w3.org/2001/04/xmlenc#sha256");
-        return new WSS4JOutInterceptor(signingProperties);
+        return new WSS4JEetOutInterceptor(signingProperties);
     }
 
     private void configureTimeout(final Client clientProxy) {

--- a/src/main/java/cz/tomasdvorak/eet/client/security/SignatureFaultInterceptor.java
+++ b/src/main/java/cz/tomasdvorak/eet/client/security/SignatureFaultInterceptor.java
@@ -1,0 +1,46 @@
+package cz.tomasdvorak.eet.client.security;
+
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.MessageContentsList;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+
+import cz.etrzby.xml.OdpovedChybaType;
+import cz.etrzby.xml.OdpovedType;
+
+/**
+ * Interecptor for conditional re-throwing of signature fault.
+ * <p>
+ * If a signature fault occurred in {@link WSS4JEetInInterceptor}, this
+ * interceptor checks the value of {@link OdpovedChybaType#getKod()} and if it
+ * was NOT an error response, the signature check fault is real and gets
+ * rethrown.
+ * <p>
+ * Error responses are not signed, therefore a fault should not be thrown.
+ * 
+ * @author Petr Kalivoda
+ *
+ */
+public class SignatureFaultInterceptor extends AbstractPhaseInterceptor<SoapMessage> {
+
+	private static final int ERR_CODE_NO_ERROR = 0;
+
+	public SignatureFaultInterceptor() {
+		super(Phase.USER_LOGICAL);
+	}
+
+	@Override
+	public void handleMessage(SoapMessage message) throws Fault {
+		if (message.getExchange().containsKey(WSS4JEetInInterceptor.PROP_SIGNATURE_ERROR)) {
+			MessageContentsList contents = MessageContentsList.getContentsList(message);
+			OdpovedType response = (OdpovedType) contents.get(0);
+			OdpovedChybaType error = response.getChyba();
+
+			if (error == null || error.getKod() == ERR_CODE_NO_ERROR) {
+				throw (Fault) message.getExchange().get(WSS4JEetInInterceptor.PROP_SIGNATURE_ERROR);
+			}
+		}
+	}
+
+}

--- a/src/main/java/cz/tomasdvorak/eet/client/security/WSS4JEetInInterceptor.java
+++ b/src/main/java/cz/tomasdvorak/eet/client/security/WSS4JEetInInterceptor.java
@@ -1,0 +1,36 @@
+package cz.tomasdvorak.eet.client.security;
+
+import java.util.Map;
+
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.ws.security.wss4j.WSS4JInInterceptor;
+
+/**
+ * Interceptor that conditinally validates EET signature based on
+ * {@link WSS4JEetOutInterceptor#PROP_SIGNATURE_REQUIRED}.
+ * 
+ * @author Petr Kalivoda
+ *
+ */
+public class WSS4JEetInInterceptor extends WSS4JInInterceptor {
+
+	protected static final String PROP_SIGNATURE_REQUIRED = "sig.required";
+	protected static final String PROP_SIGNATURE_ERROR = "sig.error";
+
+	public WSS4JEetInInterceptor(Map<String, Object> properties) {
+		super(properties);
+	}
+
+	@Override
+	public void handleMessage(SoapMessage message) throws Fault {
+		if (Boolean.TRUE.equals(message.getExchange().get(PROP_SIGNATURE_REQUIRED))) {
+			try {
+				super.handleMessage(message);
+			} catch (Fault f) {
+				// don't throw fault directly, body needs to be validated also
+				message.getExchange().put(PROP_SIGNATURE_ERROR, f);
+			}
+		}
+	}
+}

--- a/src/main/java/cz/tomasdvorak/eet/client/security/WSS4JEetOutInterceptor.java
+++ b/src/main/java/cz/tomasdvorak/eet/client/security/WSS4JEetOutInterceptor.java
@@ -1,0 +1,45 @@
+package cz.tomasdvorak.eet.client.security;
+
+import java.util.Map;
+
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.MessageContentsList;
+import org.apache.cxf.ws.security.wss4j.WSS4JOutInterceptor;
+
+import cz.etrzby.xml.TrzbaHlavickaType;
+import cz.etrzby.xml.TrzbaType;
+
+/**
+ * Specialization of {@link WSS4JOutInterceptor} that uses exchange to mark
+ * messages that have to be validated by {@link WSS4JEetInInterceptor}
+ * 
+ * @author Petr Kalivoda
+ *
+ */
+public class WSS4JEetOutInterceptor extends WSS4JOutInterceptor {
+
+	public WSS4JEetOutInterceptor(Map<String, Object> properties) {
+		super(properties);
+	}
+
+	@Override
+	public void handleMessage(SoapMessage message) throws Fault {
+		super.handleMessage(message);
+
+		MessageContentsList contents = MessageContentsList.getContentsList(message);
+		if (contents != null && contents.size() == 1) {
+			Object requestObj = contents.get(0);
+			if (requestObj instanceof TrzbaType) {
+				TrzbaType request = (TrzbaType) requestObj;
+				TrzbaHlavickaType header = request.getHlavicka();
+
+				// validation is required if isOvereni is unspecified or false.
+				boolean required = header == null || !Boolean.TRUE.equals(header.isOvereni());
+				message.getExchange().put(WSS4JEetInInterceptor.PROP_SIGNATURE_REQUIRED, required);
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
I have figured out a way to properly validate signature on EET messages using Exchange object to communicate between interceptors. This way the signature gets validated in compliance to table in signing.png without any "giant and unsecure" hacks.